### PR TITLE
fix: correct attributes for local.iam_users_access_entry_map

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -45,8 +45,8 @@ locals {
   }
 
   iam_users_access_entry_map = {
-    for role in var.map_additional_iam_users : role.rolearn => {
-      kubernetes_groups = role.groups
+    for user in var.map_additional_iam_users : user.userarn => {
+      kubernetes_groups = user.groups
     }
   }
 


### PR DESCRIPTION
## what
* Change attributes referenced in the local variable `iam_users_access_entry_map`

## why
* These are the correct attributes as read from the variable `map_additional_iam_users`
* The current release fails with an error `This object does not have an attribute named "rolearn"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated IAM user access entry mapping to use user-specific attributes instead of role-specific attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->