### PR TITLE
feat: add node auto-repair

### DIFF
--- a/src/modules/node_group_by_az/main.tf
+++ b/src/modules/node_group_by_az/main.tf
@@ -62,6 +62,7 @@ module "eks_node_group" {
   kubernetes_version         = local.enabled && length(compact([var.cluster_context.kubernetes_version])) != 0 ? [var.cluster_context.kubernetes_version] : []
   resources_to_tag           = local.enabled ? var.cluster_context.resources_to_tag : null
   subnet_ids                 = local.enabled ? local.subnet_ids : null
+  node_repair_enabled        = var.node_repair_enabled
 
   # node_userdata
   before_cluster_joining_userdata = local.enabled ? local.before_cluster_joining_userdata : []

--- a/src/modules/node_group_by_az/variables.tf
+++ b/src/modules/node_group_by_az/variables.tf
@@ -12,6 +12,12 @@ variable "node_group_size" {
   description = "The desired, minimum and maximum size of the node group in this availability zone"
 }
 
+variable "node_repair_enabled" {
+  type        = bool
+  description = "The node auto-repair configuration for the node group will be enabled. Defaults to false"
+  default     = false
+}
+
 variable "cluster_context" {
   type = object({
     ami_release_version        = string


### PR DESCRIPTION
## what

- Adds support for node-repair feature in EKS

## why

- Node auto repair is an additional feature that continuously monitors the health of nodes, automatically reacting to detected problems and replacing nodes when possible. This helps overall availability of the cluster with minimal manual intervention. If a health check fails, the node is automatically cordoned so that no new Pods are scheduled on the node.

## references

- [AWS Docs](https://docs.aws.amazon.com/eks/latest/userguide/node-health.html)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new option to enable or disable node auto-repair for node groups. By default, this feature is turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->