### PR TITLE
chore(deps): restrict aws provider version to < 6.0.0

### DIFF
--- a/src/modules/node_group_by_az/versions.tf
+++ b/src/modules/node_group_by_az/versions.tf
@@ -19,3 +19,4 @@ terraform {
       version = ">= 3.0"
     }
   }
+}

--- a/src/modules/node_group_by_az/versions.tf
+++ b/src/modules/node_group_by_az/versions.tf
@@ -8,7 +8,7 @@ terraform {
       # Windows support starts at 4.48 https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4480-december-19-2022
       # SSM parameter `insecure_value` starts at 5.8
       source  = "hashicorp/aws"
-      version = ">= 5.8"
+      version = ">= 5.8, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -19,4 +19,3 @@ terraform {
       version = ">= 3.0"
     }
   }
-}

--- a/src/modules/node_group_by_region/versions.tf
+++ b/src/modules/node_group_by_region/versions.tf
@@ -19,3 +19,4 @@ terraform {
       version = ">= 3.0"
     }
   }
+}

--- a/src/modules/node_group_by_region/versions.tf
+++ b/src/modules/node_group_by_region/versions.tf
@@ -8,7 +8,7 @@ terraform {
       # Windows support starts at 4.48 https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4480-december-19-2022
       # SSM parameter `insecure_value` starts at 5.8
       source  = "hashicorp/aws"
-      version = ">= 5.8"
+      version = ">= 5.8, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"
@@ -19,4 +19,3 @@ terraform {
       version = ">= 3.0"
     }
   }
-}

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0"
+      version = ">= 4.9.0, < 6.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This pull request includes a version constraint update for the AWS provider in the Terraform configuration file `src/versions.tf`. The change ensures compatibility with versions up to but not including 6.0.0.

* `src/versions.tf`: Updated the version constraint for the `aws` provider to `>= 4.9.0, < 6.0.0` to ensure compatibility with future versions while avoiding potential breaking changes in version 6.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AWS provider version constraints to restrict usage to versions below 6.0.0 across relevant modules and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->