### PR TITLE
docs: fix component example

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -242,7 +242,7 @@ description: |-
             - aws_team_role: planner
               groups:
                 - idp:observer
-            - aws_team: terraform
+            - aws_team_role: terraform
               groups:
                 - system:masters
 


### PR DESCRIPTION
## what
* The example was invalid due to incorrect value `aws_team` instead of `aws_team_role`

## why
* Deploy would break with an invalid error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration key naming for the Terraform team role in the YAML documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->