### PR TITLE
feat(karpenter): add ECR Public read-only IAM policy for node role

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | Name | Type |
 |------|------|
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.ecr_public_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.amazon_ec2_container_registry_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -580,11 +581,13 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | [aws_iam_role_policy_attachment.amazon_ssm_managed_instance_core](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_efs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ecr_public_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [random_pet.camel_case_warning](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_availability_zones.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecr_public_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_cni_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_roles.sso_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_roles) | data source |
@@ -631,6 +634,8 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | <a name="input_fargate_profile_iam_role_permissions_boundary"></a> [fargate\_profile\_iam\_role\_permissions\_boundary](#input\_fargate\_profile\_iam\_role\_permissions\_boundary) | If provided, all Fargate Profiles IAM roles will be created with this permissions boundary attached | `string` | `null` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | Fargate Profiles config | <pre>map(object({<br/>    kubernetes_namespace = string<br/>    kubernetes_labels    = map(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_karpenter_ecr_public_enabled"></a> [karpenter\_ecr\_public\_enabled](#input\_karpenter\_ecr\_public\_enabled) | Flag to enable/disable ECR Public read-only access for the Karpenter node role. When enabled, attaches a policy granting ecr-public and sts:GetServiceBearerToken permissions to allow authenticated pulls from public.ecr.aws | `bool` | `false` | no |
+| <a name="input_karpenter_ecr_public_resources"></a> [karpenter\_ecr\_public\_resources](#input\_karpenter\_ecr\_public\_resources) | List of ECR Public resource ARNs to scope the read-only policy. Use `["*"]` for all repositories or specify ARNs to restrict access. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_karpenter_iam_role_enabled"></a> [karpenter\_iam\_role\_enabled](#input\_karpenter\_iam\_role\_enabled) | Flag to enable/disable creation of IAM role for EC2 Instance Profile that is attached to the nodes launched by Karpenter | `bool` | `false` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |

--- a/src/README.md
+++ b/src/README.md
@@ -521,6 +521,7 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | Name | Type |
 |------|------|
 | [aws_iam_instance_profile.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.ecr_public_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.karpenter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.amazon_ec2_container_registry_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -528,11 +529,13 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | [aws_iam_role_policy_attachment.amazon_ssm_managed_instance_core](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.aws_efs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ecr_public_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [random_pet.camel_case_warning](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_availability_zones.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecr_public_readonly](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ipv6_eks_cni_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpc_cni_ipv6](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_roles.sso_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_roles) | data source |
@@ -579,6 +582,8 @@ If the new addon requires an EKS IAM Role for Kubernetes Service Account, perfor
 | <a name="input_fargate_profile_iam_role_permissions_boundary"></a> [fargate\_profile\_iam\_role\_permissions\_boundary](#input\_fargate\_profile\_iam\_role\_permissions\_boundary) | If provided, all Fargate Profiles IAM roles will be created with this permissions boundary attached | `string` | `null` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | Fargate Profiles config | <pre>map(object({<br/>    kubernetes_namespace = string<br/>    kubernetes_labels    = map(string)<br/>  }))</pre> | `{}` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
+| <a name="input_karpenter_ecr_public_enabled"></a> [karpenter\_ecr\_public\_enabled](#input\_karpenter\_ecr\_public\_enabled) | Flag to enable/disable ECR Public read-only access for the Karpenter node role. When enabled, attaches a policy granting ecr-public and sts:GetServiceBearerToken permissions to allow authenticated pulls from public.ecr.aws | `bool` | `false` | no |
+| <a name="input_karpenter_ecr_public_resources"></a> [karpenter\_ecr\_public\_resources](#input\_karpenter\_ecr\_public\_resources) | List of ECR Public resource ARNs to scope the read-only policy. Use `["*"]` for all repositories or specify ARNs to restrict access. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_karpenter_iam_role_enabled"></a> [karpenter\_iam\_role\_enabled](#input\_karpenter\_iam\_role\_enabled) | Flag to enable/disable creation of IAM role for EC2 Instance Profile that is attached to the nodes launched by Karpenter | `bool` | `false` | no |
 | <a name="input_label_key_case"></a> [label\_key\_case](#input\_label\_key\_case) | Controls the letter case of the `tags` keys (label names) for tags generated by this module.<br/>Does not affect keys of tags passed in via the `tags` input.<br/>Possible values: `lower`, `title`, `upper`.<br/>Default value: `title`. | `string` | `null` | no |
 | <a name="input_label_order"></a> [label\_order](#input\_label\_order) | The order in which the labels (ID elements) appear in the `id`.<br/>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br/>You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present. | `list(string)` | `null` | no |

--- a/src/karpenter.tf
+++ b/src/karpenter.tf
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "ecr_public_readonly" {
       "ecr-public:ListTagsForResource",
       "ecr-public:DescribeImageTags"
     ]
-    resources = ["*"]
+    resources = var.karpenter_ecr_public_resources
   }
 
   statement {

--- a/src/karpenter.tf
+++ b/src/karpenter.tf
@@ -138,3 +138,50 @@ resource "aws_iam_role_policy_attachment" "ipv6_eks_cni_policy" {
   role       = one(aws_iam_role.karpenter[*].name)
   policy_arn = one(aws_iam_policy.ipv6_eks_cni_policy[*].arn)
 }
+
+# ECR Public read-only access policy for Karpenter nodes
+# Allows authenticated pulls from public.ecr.aws to avoid throttling
+data "aws_iam_policy_document" "ecr_public_readonly" {
+  count = local.karpenter_iam_role_enabled && var.karpenter_ecr_public_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr-public:GetAuthorizationToken",
+      "ecr-public:BatchGetImage",
+      "ecr-public:GetDownloadUrlForLayer",
+      "ecr-public:DescribeRepositories",
+      "ecr-public:DescribeImages",
+      "ecr-public:ListImages",
+      "ecr-public:GetRepositoryCatalogData",
+      "ecr-public:GetRegistryCatalogData",
+      "ecr-public:ListTagsForResource",
+      "ecr-public:DescribeImageTags"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:GetServiceBearerToken"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ecr_public_readonly" {
+  count = local.karpenter_iam_role_enabled && var.karpenter_ecr_public_enabled ? 1 : 0
+
+  name        = "${module.this.id}-ECRPublicReadOnly"
+  description = "ECR Public read-only access for Karpenter nodes"
+  policy      = data.aws_iam_policy_document.ecr_public_readonly[0].json
+  tags        = module.karpenter_label.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_public_readonly" {
+  count = local.karpenter_iam_role_enabled && var.karpenter_ecr_public_enabled ? 1 : 0
+
+  role       = one(aws_iam_role.karpenter[*].name)
+  policy_arn = one(aws_iam_policy.ecr_public_readonly[*].arn)
+}

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -466,6 +466,13 @@ variable "karpenter_ecr_public_enabled" {
   nullable    = false
 }
 
+variable "karpenter_ecr_public_resources" {
+  type        = list(string)
+  description = "List of ECR Public resource ARNs to scope the read-only policy. Use `[\"*\"]` for all repositories or specify ARNs to restrict access."
+  default     = ["*"]
+  nullable    = false
+}
+
 variable "fargate_profiles" {
   type = map(object({
     kubernetes_namespace = string

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -459,6 +459,13 @@ variable "karpenter_iam_role_enabled" {
   nullable    = false
 }
 
+variable "karpenter_ecr_public_enabled" {
+  type        = bool
+  description = "Flag to enable/disable ECR Public read-only access for the Karpenter node role. When enabled, attaches a policy granting ecr-public and sts:GetServiceBearerToken permissions to allow authenticated pulls from public.ecr.aws"
+  default     = false
+  nullable    = false
+}
+
 variable "fargate_profiles" {
   type = map(object({
     kubernetes_namespace = string


### PR DESCRIPTION
Add support for ECR Public read-only access in the Karpenter node IAM role.

The new `karpenter_ecr_public_enabled` variable (default `false`) creates and attaches an IAM policy granting ecr-public and sts:GetServiceBearerToken permissions to the Karpenter node role. This allows Karpenter-launched nodes to perform authenticated pulls from public.ecr.aws, avoiding throttling.

Policy includes all required ecr-public actions for pulling public container images and the sts:GetServiceBearerToken action needed for ECR Public authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional ECR Public read-only access for Karpenter nodes via a feature flag (defaults to off). When enabled, nodes can perform authenticated pulls from public.ecr.aws.
  * Added the ability to scope access to specific ECR Public repositories using a configurable list of resource ARNs.
* **Documentation**
  * Updated docs to describe the new flag and resource-scoping option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->