### PR TITLE
Update GitHub Actions IAM role module version

### DIFF
--- a/mixins/github-actions-iam-role.mixin.tf
+++ b/mixins/github-actions-iam-role.mixin.tf
@@ -48,7 +48,7 @@ module "gha_role_name" {
 }
 
 module "gha_assume_role" {
-  source = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/team-assume-role-policy?ref=v1.536.1"
+  source = "github.com/cloudposse-terraform-components/aws-account-map//src/modules/team-assume-role-policy?ref=v1.537.2"
 
   trusted_github_repos = var.github_actions_allowed_repos
   privileged           = var.privileged


### PR DESCRIPTION
Version 2.0 Cloudposse/Utils Provider

This pull request updates the version of the `team-assume-role-policy` module used in the `mixins/github-actions-iam-role.mixin.tf` file. The update moves from version `v1.536.1` to `v1.537.2`, ensuring that the latest improvements and bug fixes from the upstream module are incorporated.

Dependency update:

* Updated the `team-assume-role-policy` module source to version `v1.537.2` in `mixins/github-actions-iam-role.mixin.tf` to use the latest module changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream Terraform module dependency for GitHub Actions IAM role configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->